### PR TITLE
Help flag update and consider all commits option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ build/
 
 # Directory created by dartdoc
 doc/api/
+
+# Application specific
+results.csv
+peot

--- a/README.md
+++ b/README.md
@@ -12,14 +12,48 @@ The target project must use git for version control.
 - [composer installed globally](https://getcomposer.org/doc/00-intro.md#globally)
 
 ## Installation
-// TODO compiled
-// TODO Build
-// TODO Dart
+Option 1 (recommended): Download the latest [release](https://github.com/Andrew-Mackay/peot/releases).
+
+Option 2: Download the repository and compile yourself. Instructions on how to do this can be found [here](https://dart.dev/tutorials/server/get-started#6-compile-for-production).
+
+Option 3: Download the repository and run using the Dart VM. 
+```
+dart bin/peot.dart
+```
+
 
 ## Usage
-// TODO
+```
+$ peot -h
 
-## Example Results
+peot (psalm errors over time)
+
+Reports the number of static errors in a PHP project over time by running the 
+psalm static code analysis tool.
+
+Usage: peot <git-repository> [args]
+
+Results will be written to results.csv.
+
+    --from                    Date to start the analysis from in format YYYY-MM-DD. Example: 2020-02-24.
+    --to                      Date to run the analysis until in format YYYY-MM-DD. Example: 2020-02-24.
+    --psalm-config            Path to the desired psalm.xml configuration file. If this argument is not
+                              provided, the program will check for an existing psalm.xml file in the project
+                              repository. If no psalm.xml is found in the project repository, a new psalm.xml
+                              file will be initialised using `psalm --init`.
+    --frequency               How frequently to analyse the project.
+                              [all, daily, weekly, monthly (default), yearly]
+    --psalm-version           Which psalm version to use.
+                              (defaults to "4.1.1")
+-a, --consider-all-commits    By default, analysis is only run on merge commits into the main/master branch.
+                              This is found to give a more accurate insight into the state of the codebase
+                              over time for projects using some form of branching strategy. Use this flag to
+                              override this behaviour and instead consider all commits in the analysis.
+-h, --help                    Print this usage information.
+
+```
+
+## Examples
 Graphing of data has been done manually using google sheets
 
 // TODO

--- a/bin/peot.dart
+++ b/bin/peot.dart
@@ -16,6 +16,7 @@ Future<void> main(List<String> arguments) async {
     args.to,
     args.frequency,
     args.psalmVersion,
+    args.considerAllCommits,
   );
 
   await csv_writer.writePsalmErrorsOverTimeToCSV(numberOfErrorsOverTime);

--- a/lib/argument_parser.dart
+++ b/lib/argument_parser.dart
@@ -12,7 +12,7 @@ Future<Arguments> parseArguments(List<String> arguments) async {
       help: '''
 Path for psalm.xml configuration file.
 If not provided will try to use existing psalm.xml in repository.
-If no psalm.xml found, will initlise new psalm.xml using `psalm --init`
+If no psalm.xml found, will initialise new psalm.xml using `psalm --init`
       ''',
     )
     ..addOption(

--- a/lib/psalm_errors_over_time.dart
+++ b/lib/psalm_errors_over_time.dart
@@ -16,6 +16,7 @@ Future<Map<DateTime, AnalysisResult>> getPsalmErrorsOverTime(
   DateTime to,
   Duration frequency,
   String psalmVersion,
+  bool considerAllCommits,
 ) async {
   print('Creating temporary directory...');
   var temporaryDirectory =
@@ -39,10 +40,17 @@ Future<Map<DateTime, AnalysisResult>> getPsalmErrorsOverTime(
     }
 
     print('Collecting commits...');
-    var commits = await git.getCommits(from, to, frequency, projectDirectory);
+    var commits = await git.getCommits(
+      from,
+      to,
+      frequency,
+      projectDirectory,
+      considerAllCommits,
+    );
     print('Found ${commits.length} commits\n');
 
-    return (await _analyseCommits(commits, projectDirectory, psalmConfig, psalmVersion));
+    return (await _analyseCommits(
+        commits, projectDirectory, psalmConfig, psalmVersion));
   } finally {
     print('Deleting temporary directory...');
     await temporaryDirectory.delete(recursive: true);
@@ -57,8 +65,8 @@ Future<Map<DateTime, AnalysisResult>> _analyseCommits(
 ) async {
   var psalmErrorsOverTime = <DateTime, AnalysisResult>{};
   for (var commit in commits) {
-    var result =
-        await _analyseCommit(commit, projectDirectory, psalmConfigLocation, psalmVersion);
+    var result = await _analyseCommit(
+        commit, projectDirectory, psalmConfigLocation, psalmVersion);
     psalmErrorsOverTime[result.date] = result;
 
     print('Resetting git branch...');


### PR DESCRIPTION
- Update the usage information shown by the help flag
- Add new flag 'consider-all-commits' to not limit the commits to merges
- Add help section to the readme